### PR TITLE
Add the Azure Boards badge to the README

### DIFF
--- a/.github/workflows/board.yml
+++ b/.github/workflows/board.yml
@@ -1,0 +1,22 @@
+name: Sync Pull Request to Azure Boards
+
+on:
+  pull_request:
+    types: [opened, edited, closed]
+    branches:
+      - master
+
+jobs:
+  alert:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: danhellem/github-actions-pr-to-work-item@master
+      env:
+        ado_token: '${{ secrets.ADO_PERSONAL_ACCESS_TOKEN }}'   
+        github_token: '${{ secrets.TOKEN_HUB }}'    
+        ado_organization: 'privatepreview'
+        ado_project: 'Agile'
+        ado_wit: 'Pull Request' 
+        ado_new_state: 'New'
+        ado_active_state: 'Active'
+        ado_close_state: 'Closed'

--- a/README.md
+++ b/README.md
@@ -1,3 +1,4 @@
+[![Board Status](https://dev.azure.com/anurenjinija/2768ccd7-d6cc-4421-815a-3207a8f5b1ad/42cf5bd2-fac9-4dfc-9ed0-5c3e0448f6aa/_apis/work/boardbadge/ece43229-717b-49b4-9f80-6e31b2939393)](https://dev.azure.com/anurenjinija/2768ccd7-d6cc-4421-815a-3207a8f5b1ad/_boards/board/t/42cf5bd2-fac9-4dfc-9ed0-5c3e0448f6aa/Microsoft.RequirementCategory)
 ## Welcome
 
 This repositoryy contains the base project part of our on-site GitHub Verified Partner workshop program. It is meant to be used for in-classroom training under the supervision of GitHub coaches.


### PR DESCRIPTION
Add the Azure Boards badge for the board used to track the work for this repository. Fixes [AB#198](https://dev.azure.com/anurenjinija/2768ccd7-d6cc-4421-815a-3207a8f5b1ad/_workitems/edit/198). See the [status badge configuration](https://aka.ms/azureboardsgithub-badge) documentation for more information.